### PR TITLE
changed tagline to lowercase

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
   <time datetime="{{ .Date }}">{{ dateFormat "2006/01/02" .Date }}</time>
   {{ end }}
 
-  {{ if and .IsHome (isset .Site.Params "Tagline") }}
+  {{ if and .IsHome (isset .Site.Params "tagline") }}
   <p>{{ .Site.Params.Tagline }}</p>
   {{ end }}
 </header>


### PR DESCRIPTION
Hugo docs notes that all site-level configuration
keys are stored lowercase.

https://gohugo.io/functions/isset/#readout